### PR TITLE
DateFormat enhancement and utc

### DIFF
--- a/NLog.Extensions.AzureTableStorage/LogEntity.cs
+++ b/NLog.Extensions.AzureTableStorage/LogEntity.cs
@@ -14,7 +14,10 @@ namespace NLog.Extensions.AzureTableStorage
             lock (_syncRoot)
             {
                 LoggerName = logEvent.LoggerName;
-                LogTimeStamp = logEvent.TimeStamp.ToString("g");
+                //logging as UTC time so would be consistant across geo locations
+                //format is not quite UTC as didn't want to lose millisecond precision but it is culturally neutral
+                //it should also allow for predictable parsing when reading this back out of azure storage
+                LogTimeStamp = logEvent.TimeStamp.ToUniversalTime().ToString("yyyy-MM-dd HH:mm:ss.fff");
                 Level = logEvent.Level.Name;
                 Message = logEvent.FormattedMessage;
                 MessageWithLayout = layoutMessage;


### PR DESCRIPTION
Hi,

I've used Nlog a lot and read your issue
https://github.com/harouny/NLog.Extensions.AzureTableStorage/issues/8

The inline comments sum up where I'm coming from with, repeated below
//logging as UTC time so would be consistant across geo locations
//format is not quite UTC as didn't want to lose millisecond precision but it is culturally neutral
//it should also allow for predictable parsing when reading this back out of azure storage

Otherwise like this a lot, tidy work.

Regards,
Colum
