### PR TITLE
Support for DateTime PartitionKey prefix and support for specifying format string for LogTimeStamp

### DIFF
--- a/NLog.Extensions.AzureTableStorage.Tests/AzureTableStorageTargetTests.cs
+++ b/NLog.Extensions.AzureTableStorage.Tests/AzureTableStorageTargetTests.cs
@@ -116,6 +116,14 @@ namespace NLog.Extensions.AzureTableStorage.Tests
         }
 
         [Fact]
+        public void IncludePartitionKeyDatePrefix()
+        {
+            _logger.Log(LogLevel.Trace, "this entity's partition key should be prefixed with a date");
+            var entity = GetLogEntities().Single();
+            Assert.True(entity.PartitionKey.StartsWith(DateTime.Now.ToString("yyyy-MM-dd")));
+        }
+
+        [Fact]
         public void IncludeMachineName()
         {
             var exception = new NullReferenceException();
@@ -155,8 +163,8 @@ namespace NLog.Extensions.AzureTableStorage.Tests
         private List<LogEntity> GetLogEntities()
         {
             // Construct the query operation for all customer entities where PartitionKey="Smith".
-            var query = new TableQuery<LogEntity>()
-                .Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, "customPrefix." + GetType()));
+            var query = new TableQuery<LogEntity>();
+               // .Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, "customPrefix." + GetType()));
             var entities = _cloudTable.ExecuteQuery(query);
             return entities.ToList();
         }

--- a/NLog.Extensions.AzureTableStorage.Tests/AzureTableStorageTargetTests.cs
+++ b/NLog.Extensions.AzureTableStorage.Tests/AzureTableStorageTargetTests.cs
@@ -124,6 +124,14 @@ namespace NLog.Extensions.AzureTableStorage.Tests
         }
 
         [Fact]
+        public void LogTimestampIsFormatted()
+        {
+            _logger.Log(LogLevel.Trace, "this entity's log timestamp should include .000 for milliseconds");
+            var entity = GetLogEntities().Single();
+            Assert.True(entity.LogTimeStamp.EndsWith(".000"));
+        }
+
+        [Fact]
         public void IncludeMachineName()
         {
             var exception = new NullReferenceException();

--- a/NLog.Extensions.AzureTableStorage.Tests/NLog.config
+++ b/NLog.Extensions.AzureTableStorage.Tests/NLog.config
@@ -6,8 +6,12 @@
   </extensions>
   <targets>
     <target name="AzureTableStorage" xsi:type="AzureTableStorage" PartitionKeyPrefix="customPrefix" connectionStringKey="StorageAccountConnectionString" tableName="TempAzureTableStorageTargetTestsLogs" />
+    <target name="AzureTableStorage2" xsi:type="AzureTableStorage" connectionStringKey="StorageAccountConnectionString" 
+            tableName="TempAzureTableStorageTargetTestsLogs" PartitionKeyPrefixDateFormat="yyyy-MM-dd" />
+
   </targets>
   <rules>
-    <logger name="*" minlevel="Trace" writeTo="AzureTableStorage" />
+    <logger name="*" minlevel="Debug" writeTo="AzureTableStorage" />
+    <logger name="*" minlevel="Trace" maxlevel="Trace" writeTo="AzureTableStorage2" />
   </rules>
 </nlog>

--- a/NLog.Extensions.AzureTableStorage.Tests/NLog.config
+++ b/NLog.Extensions.AzureTableStorage.Tests/NLog.config
@@ -7,7 +7,7 @@
   <targets>
     <target name="AzureTableStorage" xsi:type="AzureTableStorage" PartitionKeyPrefix="customPrefix" connectionStringKey="StorageAccountConnectionString" tableName="TempAzureTableStorageTargetTestsLogs" />
     <target name="AzureTableStorage2" xsi:type="AzureTableStorage" connectionStringKey="StorageAccountConnectionString" 
-            tableName="TempAzureTableStorageTargetTestsLogs" PartitionKeyPrefixDateFormat="yyyy-MM-dd" />
+            tableName="TempAzureTableStorageTargetTestsLogs" PartitionKeyPrefixDateFormat="yyyy-MM-dd" LogTimestampFormatString="yyyy-MM-dd hh:mm:ss.000"/>
 
   </targets>
   <rules>

--- a/NLog.Extensions.AzureTableStorage/AzureTableStorageTarget.cs
+++ b/NLog.Extensions.AzureTableStorage/AzureTableStorageTarget.cs
@@ -20,6 +20,8 @@ namespace NLog.Extensions.AzureTableStorage
         public string PartitionKeyPrefixKey { get; set; }
         public string PartitionKeyPrefixDateFormat { get; set; }
 
+        public string LogTimestampFormatString { get; set; }
+
         protected override void InitializeTarget()
         {
             base.InitializeTarget();
@@ -61,7 +63,15 @@ namespace NLog.Extensions.AzureTableStorage
             if (_tableStorageManager != null)
             {
                 var layoutMessage = Layout.Render(logEvent);
-                _tableStorageManager.Add(new LogEntity(PartitionKeyPrefix, logEvent, layoutMessage));
+
+                if (string.IsNullOrEmpty(LogTimestampFormatString))
+                {
+                    _tableStorageManager.Add(new LogEntity(PartitionKeyPrefix, logEvent, layoutMessage));
+                }
+                else
+                {
+                    _tableStorageManager.Add(new LogEntity(PartitionKeyPrefix, logEvent, layoutMessage, LogTimestampFormatString));
+                }
             }
         }
     }

--- a/NLog.Extensions.AzureTableStorage/AzureTableStorageTarget.cs
+++ b/NLog.Extensions.AzureTableStorage/AzureTableStorageTarget.cs
@@ -18,6 +18,7 @@ namespace NLog.Extensions.AzureTableStorage
 
         public string PartitionKeyPrefix { get; set; }
         public string PartitionKeyPrefixKey { get; set; }
+        public string PartitionKeyPrefixDateFormat { get; set; }
 
         protected override void InitializeTarget()
         {
@@ -26,8 +27,16 @@ namespace NLog.Extensions.AzureTableStorage
             _configManager = new ConfigManager(ConnectionStringKey);
             _tableStorageManager = new TableStorageManager(_configManager, TableName);
 
+            // use PartitionKeyPrefixKey if present
             if (!string.IsNullOrWhiteSpace(PartitionKeyPrefixKey))
+            {
                 PartitionKeyPrefix = _configManager.GetSettingByKey(PartitionKeyPrefixKey);
+            }
+            // else use PartitionKeyPrefixDateFormat if available
+            else if (!string.IsNullOrWhiteSpace(PartitionKeyPrefixDateFormat))
+            {
+                PartitionKeyPrefix = DateTime.UtcNow.ToString(PartitionKeyPrefixDateFormat);
+            }
         }
 
         private void ValidateParameters()

--- a/NLog.Extensions.AzureTableStorage/LogEntity.cs
+++ b/NLog.Extensions.AzureTableStorage/LogEntity.cs
@@ -9,12 +9,12 @@ namespace NLog.Extensions.AzureTableStorage
     {
         private readonly object _syncRoot = new object();
 
-        public LogEntity(string partitionKeyPrefix, LogEventInfo logEvent, string layoutMessage)
+        public LogEntity(string partitionKeyPrefix, LogEventInfo logEvent, string layoutMessage, string timestampFormatString = "g")
         {
             lock (_syncRoot)
             {
                 LoggerName = logEvent.LoggerName;
-                LogTimeStamp = logEvent.TimeStamp.ToString("g");
+                LogTimeStamp = logEvent.TimeStamp.ToString(timestampFormatString);
                 Level = logEvent.Level.Name;
                 Message = logEvent.FormattedMessage;
                 MessageWithLayout = layoutMessage;

--- a/README.md
+++ b/README.md
@@ -28,13 +28,20 @@ How to use
             ConnectionStringKey="[[connection-string-key]]" 
             TableName="[[table-name]]"
 			PartitionKeyPrefix="[[partition-key-prefix-value]]"
-			PartitionKeyPrefixKey="[[partition-key-prefix-configuration-key]]" />
+			PartitionKeyPrefixKey="[[partition-key-prefix-configuration-key]]" 
+			PartitionKeyPrefixDateFormat="[[datetime-format-value]]"
+			LogTimestampFormatString="[[datetime-format-string]]"
+			/>
   </targets>
 `````
 Where ```[[target-name]]``` is a name you give for the target, ```[[connection-string-key]]``` is the key of Azure Storage Account connection string setting in App Settings or Cloud Service configuration file, and ```[[table-name]]``` is a name you give to the log table that will be created.
 
 If multiple applications need to share the same storage account it is possible to prefix the partition keys used with a custom string.
 ```[[PartitionKeyPrefix]]``` and ```[[PartitionKeyPrefixKey]]``` are optional and ```[[PartitionKeyPrefixKey]]``` has precedence over a hard coded value in ```[[PartitionKeyPrefix]]```. 
+Further, you can use ```[[PartitionKeyPrefixDateFormat]]``` to provide a standard DateTime format string to prefix the partition with, which may result in a better partitioning strategy in some use cases.
+
+Optionally specify a value for ```[[LogTimestampFormatString]]``` to override the default format string of "g" for the LogTimeStamp field.
+
 - Add a rule that uses the target in ```rules``` section.
 `````xml
   <rules>


### PR DESCRIPTION
In some applications, a non changing PartitionKey (even if prefixed) creates a poor partitioning strategy and poor performance in table storage (especially in logging type tables where there are many entities over time).

Modifying the partition key based on date can improve performance. These changes implement that by adding a new PartitionKeyPrefixDateFormat attribute to the target definition, which takes lower priority that the exiting PartitionKeyPrefixKey, which allows the user to provide a standard .net datetime format string to prefix the PartitionKey with. This can, for example, be "yyyy-MM-dd" to change keys daily, or "yyyy-MM" to change monthly etc.


The other change is to add an optional property LogTimestampFormatString which if provided allows the user to specify their own format string for the LogTimeStamp (for example, to specify a format which includes milliseconds).


I've also added tests for both new features and updated the README